### PR TITLE
clean up artifacts after sync:to_local

### DIFF
--- a/lib/synchronizer/assets.rb
+++ b/lib/synchronizer/assets.rb
@@ -7,7 +7,6 @@ module Assets
     end
   end
 
-
   def copy_assets_to_local
     download! "#{fetch(:assets_archive_file)}", "#{fetch(:assets_archive_file).split('/')[-1]}"
     download! "#{fetch(:storage_archive_file)}", "#{fetch(:storage_archive_file).split('/')[-1]}"
@@ -21,7 +20,6 @@ module Assets
       raise "missing variable sync_assets_to"
     end
   end
-
 
   private
 

--- a/lib/synchronizer/helper.rb
+++ b/lib/synchronizer/helper.rb
@@ -4,11 +4,11 @@ module Helper
     puts "deprecated... will vanish soon..."
     _stage =  fetch(:stage, nil).to_s
     dest = fetch(:sync_to, nil)
-    if dest 
+    if dest
       dest
     else
       ask(:sync_to, stages.delete_if { |x| x == _stage }.join('|') )
-      dest = fetch(:sync_to, nil) 
+      dest = fetch(:sync_to, nil)
     end
   end
 
@@ -19,6 +19,21 @@ module Helper
   def _cset(name, *args, &block)
     unless exists?(name)
       set(name, *args, &block)
+    end
+  end
+
+  def clean_db_dump
+    if test("[ -f '#{fetch(:db_dump_file)}' ]")
+      execute :rm, '-v', fetch(:db_dump_file)
+    end
+  end
+
+  def clean_assets_dump
+    if test("[ -f '#{fetch(:assets_archive_file)}' ]")
+      execute :rm, '-v', fetch(:assets_archive_file)
+    end
+    if test("[ -f '#{fetch(:storage_archive_file)}' ]")
+      execute :rm, '-v', fetch(:storage_archive_file)
     end
   end
 end


### PR DESCRIPTION
this PR will cleanup generated artifacts (assets tgz & postgresql dump) after synchronisation to local

also included are tasks to keep the assets (i.e. the former behavior)